### PR TITLE
Python 3 compatibility

### DIFF
--- a/app_entitlements.py
+++ b/app_entitlements.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 """Uses python's pprint to 'pretty print' the entitlements of an app (if they exist) that has been codesigned."""
 
+from __future__ import absolute_import, print_function
+
 import os
 import plistlib
 import sys

--- a/app_entitlements.py
+++ b/app_entitlements.py
@@ -34,8 +34,8 @@ if len(sys.argv) > 1:
     if sys.argv[1]:
         pprint(entitlements(sys.argv[1]))
     else:
-        print usage
+        print(usage)
         sys.exit(1)
 else:
-    print usage
+    print(usage)
     sys.exit(1)

--- a/tccdbRead.py
+++ b/tccdbRead.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import absolute_import, print_function
+
 import os
 import sqlite3
 import sys

--- a/tccdbRead.py
+++ b/tccdbRead.py
@@ -81,7 +81,7 @@ class ReadTCC():
                 print(' {:<35} | {}'.format('Service', 'Client'))
                 print('-----------------------------------------------------------------------')
                 for service, client in query:
-                    print((' {:<35} | {}'.format(service, client)))
+                    print(' {:<35} | {}'.format(service, client))
             self.sqlite.disconnect(self.tcc_db)
 
 

--- a/tccdbRead.py
+++ b/tccdbRead.py
@@ -71,7 +71,7 @@ class ReadTCC():
 
     def read_db(self):
         if self.tcc_db.startswith('/Library') and os.getuid() != 0:
-            print 'You must be root to read {}'.format(self.tcc_db)
+            print('You must be root to read {}'.format(self.tcc_db))
             sys.exit(1)
         else:
             self.sqlite.connect(self.tcc_db)
@@ -81,7 +81,7 @@ class ReadTCC():
                 print(' {:<35} | {}'.format('Service', 'Client'))
                 print('-----------------------------------------------------------------------')
                 for service, client in query:
-                    print (' {:<35} | {}'.format(service, client))
+                    print((' {:<35} | {}'.format(service, client)))
             self.sqlite.disconnect(self.tcc_db)
 
 

--- a/tccprofile.py
+++ b/tccprofile.py
@@ -586,7 +586,7 @@ class PrivacyProfiles(object):
             # exist because skip forward/backward in DST change over, an exception will be raised.
             try:
                 local_time = timezone.localize(local_time, is_dst=None)
-            except (pytz.exceptions.AmbiguousTimeError, pytz.exceptions.NonExistentTimeError), e:
+            except (pytz.exceptions.AmbiguousTimeError, pytz.exceptions.NonExistentTimeError) as e:
                 # If an AmbiguousTimeError occurs, it is likely because that time has occurred more than once.
                 # For example, 2002-10-27 01:30 happened twice in the US/Eastern timezone when DST ended.
                 # If a NonExistentTimeError occurs, it is because that particular point in time has not/does not occur.

--- a/tccprofile.py
+++ b/tccprofile.py
@@ -14,10 +14,19 @@ import re
 import uuid
 import subprocess
 import sys
-import Tkinter as tk
-import ttk
-import tkFileDialog
 import pytz
+
+# Tkinter
+try:
+    # Python 3
+    import tkinter as tk
+    from tkinter import ttk
+    from tkinter import filedialog as tkFileDialog
+except ImportError:
+    # Python 2
+    import Tkinter as tk
+    import ttk
+    import tkFileDialog
 
 # Imports specifically for FoundationPlist
 # PyLint cannot properly find names inside Cocoa libraries, so issues bogus

--- a/tccprofile.py
+++ b/tccprofile.py
@@ -67,8 +67,8 @@ class App(tk.Frame):
         self.master.protocol('WM_DELETE_WINDOW', self.click_quit)
         self.master.bind('<Return>', self.click_save)
 
-        x = (self.master.winfo_screenwidth() - self.master.winfo_reqwidth()) / 2
-        y = (self.master.winfo_screenheight() - self.master.winfo_reqheight()) / 4
+        x = (self.master.winfo_screenwidth() - self.master.winfo_reqwidth()) // 2
+        y = (self.master.winfo_screenheight() - self.master.winfo_reqheight()) // 4
         self.master.geometry("+{}+{}".format(x, y))
 
         self.master.config(menu=tk.Menu(self.master))

--- a/tccprofile.py
+++ b/tccprofile.py
@@ -397,9 +397,9 @@ class App(tk.Frame):
 
     @staticmethod
     def _list_signing_certs():
-        output = subprocess.check_output(
+        output = str(subprocess.check_output(
             ['/usr/bin/security', 'find-identity', '-p', 'codesigning', '-v']
-        ).split('\n')
+        )).split('\n')
 
         cert_list = ['No']
         for i in output:

--- a/tccprofile.py
+++ b/tccprofile.py
@@ -3,6 +3,8 @@
 
 # pylint: disable=line-too-long
 # pylint: disable=superfluous-parens
+from __future__ import absolute_import, print_function
+
 import argparse
 import datetime
 import errno


### PR DESCRIPTION
Makes a few changes suggested by `python-modernize`, `pylint --py3k`, and [this guide](https://portingguide.readthedocs.io/en/latest/index.html).

With these changes, in Python 3 environment with `pytz` and `PyObjC` installed, the ./tccprofile.py UI runs. (There's work to be done for making it look good in Dark Mode, though.)